### PR TITLE
Fix inability to run composer install more than once

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,24 @@
     "type": "project",
     "license": "GPL-2.0-or-later",
     "repositories": {
+        "drupal_cms_olivero": {
+            "type": "package",
+            "package": {
+                "name": "drupal/drupal_cms_olivero",
+                "version": "dev-1.x",
+                "type": "drupal-theme",
+                "source": {
+                    "type": "git",
+                    "url": "https://git.drupalcode.org/project/drupal_cms_olivero.git",
+                    "reference": "1.x"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-1.x": "1.0.x-dev"
+                    }
+                }
+            }
+        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
@@ -26,7 +44,7 @@
         "drupal/drupal_cms_events": "^1",
         "drupal/drupal_cms_forms": "^1",
         "drupal/drupal_cms_news": "^1.0.1",
-        "drupal/drupal_cms_olivero": "dev-1.x as 1.0.x-dev",
+        "drupal/drupal_cms_olivero": "1.0.x-dev",
         "drupal/drupal_cms_page": "^1.0.1",
         "drupal/drupal_cms_person": "^1.0.1",
         "drupal/drupal_cms_project": "^1",


### PR DESCRIPTION
Using an inline alias results in conflicting version constraints in the lock file.