### PR TITLE
Update README.md to remove Drupal CMS references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Experience Builder Demo for Drupal CMS
+# Pre-release demo of Drupal Experience Builder
 
 ## ⚠️ WARNING ⚠️
-This repository is intended to provide a **pre-beta demo** of Experience Builder running on top of Drupal CMS. **Experience Builder is not stable** and could change anything, at any time, without warning. There is no update path yet; data loss is possible. Additionally, this demo project will be _abandoned_ when Experience Builder reaches beta (expected in mid-2025).
+This repository is intended to provide a **pre-beta demo** of Experience Builder. **Experience Builder is not stable** and could change anything, at any time, without warning. There is no update path yet; data loss is possible. Additionally, this demo project will be _abandoned_ when Experience Builder reaches beta (expected in mid-2025).
 
 [Feedback is very welcome](https://www.drupal.org/node/add/project-issue/experience_builder), but **you ABSOLUTELY _SHOULD NOT_ use this project to build a real site.**
 
 ## About
-Experience Builder (or XB for short) is Drupal's next-generation page building tool, [currently under heavy development on drupal.org](https://www.drupal.org/project/experience_builder). If you've heard about Drupal CMS, and you're eager to try out XB, you've come to the right place. 😎
+Experience Builder (or XB for short) is Drupal's next-generation page building tool, [currently under heavy development on drupal.org](https://www.drupal.org/project/experience_builder). This is a demo package of Drupal to try out Experience Builder. 😎
 
 ## Getting Started 🚀
 We strongly recommend using [DDEV](https://ddev.com/get-started/) (version 1.24.0 or later) to run this project, since it includes everything you'll need. Run the following commands to spin up with DDEV:


### PR DESCRIPTION
Suggestion for issue #25. I think the project description also should be changed. In my fork, I changed it to "Pre-release demo of Drupal Experience Builder" which is the same as the README title. It is also not true that the demo does not allow saving, which could in itself throw people off (it threw me off before for sure).