### PR TITLE
Fix composer update failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "conflict": {
         "drupal/drupal": "*"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
Drupal 11.x-dev requires symfony/console:^7.3@beta, but our minimum-stability is set to stable. The minimum-stability setting prevents composer updates from running.